### PR TITLE
ci - add tauri builds

### DIFF
--- a/.github/workflows/main-release.yaml
+++ b/.github/workflows/main-release.yaml
@@ -40,3 +40,34 @@ jobs:
           ORG: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           GITHUB_WORKFLOW: ${{ github.workflow }}
+
+  build-tauri:
+    runs-on: [macos-latest]
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Rust setup
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust Cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "./src-tauri -> target"
+
+      - name: Set up Nodejs
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      - name: Install frontend dependencies
+        run: cd tauri && npm install
+
+      - name: Tauri build
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectPath: "./tauri"

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -36,3 +36,64 @@ jobs:
           ORG: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           GITHUB_WORKFLOW: ${{ github.workflow }}
+
+  build-tauri:
+    runs-on: [macos-latest]
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Rust setup
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust Cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "./src-tauri -> target"
+
+      - name: Set up Nodejs
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+
+      - name: Install Frontend deps
+        run: |
+          npm install
+
+      - name: Populate key
+        run: |
+          echo "${{ secrets.APPLE_API_KEY_B64 }}"|base64 --decode > ./apple.p8
+
+      - name: get release version
+        id: get_release_version
+        run: echo "TAG=${GITHUB_REF#refs/tags/}"" >>  $GITHUB_ENV
+
+      - name: Build the app
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_PATH: ./apple.p8
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+        with:
+          releaseId: ${process.env.TAG}
+
+      - name: publish release
+        id: publish-release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: process.env.TAG,
+            })

--- a/tauri/scripts/bundle-prep.sh
+++ b/tauri/scripts/bundle-prep.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+pushd $(dirname $0)/..
+
+mkdir -p ./src-tauri/assets
 cp ../docker-compose.yml ./src-tauri/assets/docker-compose.yml
+popd


### PR DESCRIPTION
Adds support for Tauri builds on main to verify it builds correctly. no artifact is published.
Adds support for Tauri publishing on tagged releases.