### PR TITLE
fix: make host.docker.internal reference work on Linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,8 @@ services:
       start_period: 40s
     networks:
       - rubra
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   text-embedding-api:
     build:


### PR DESCRIPTION
host.docker.internal is not necessarily present on all systems (e.g. not on my Linux machine - it's there by default in Docker Desktop though), but it is used as a default connection string to Llamafile by LiteLLM, so we can just "hardcode" it in the docker-compose file.
`host-gateway` is a special DNS key that will be replaced with Docker's host gateway IP and written to /etc/hosts inside the container.

Please test this on Mac or Win with Docker Desktop to ensure it doesn't break those.